### PR TITLE
fix: parse repository and action from GitHub webhook event

### DIFF
--- a/cmd/simili/commands/process.go
+++ b/cmd/simili/commands/process.go
@@ -161,9 +161,26 @@ func runProcess() {
 					}
 				}
 
+				// Handle repository
+				if repo, ok := raw["repository"].(map[string]interface{}); ok {
+					if owner, ok := repo["owner"].(map[string]interface{}); ok {
+						if login, ok := owner["login"].(string); ok {
+							issue.Org = login
+						}
+					}
+					if name, ok := repo["name"].(string); ok {
+						issue.Repo = name
+					}
+				}
+
 				// Fallback event name from GitHub environment if possible
 				if issue.EventType == "" {
 					issue.EventType = os.Getenv("GITHUB_EVENT_NAME")
+				}
+
+				// Handle event action if provided
+				if action, ok := raw["action"].(string); ok {
+					issue.EventAction = action
 				}
 			}
 		}


### PR DESCRIPTION
## Summary

Fixed critical bug where the bot was skipping all issues with "repository not configured" error when repository lists were populated.

## Problem

The `process.go` command was not parsing the GitHub webhook `repository` object to extract org/repo values needed for configuration matching. This caused all webhook-triggered issues to be rejected at the gatekeeper stage.

## Solution

Added proper extraction from GitHub webhook payload:
- `repository.owner.login` → `issue.Org`
- `repository.name` → `issue.Repo`  
- Top-level `action` field → `issue.EventAction` (required for transfer loop prevention)

This enables:
1. Repository configuration matching to work correctly
2. Transfer loop prevention to detect transferred events
3. Proper pipeline processing for all webhooks

## Related Fixes

This PR builds on previously merged fixes:
- **#25**: Transfer loop prevention + cross-repo search default + table formatting

This PR: Repository parsing bug that was blocking those features from working

## Testing

✅ `go build ./...` - PASS
✅ `go test ./...` - PASS (all tests)
✅ Integration tests verified:
  - Repository matching works
  - Transfer event detection works (action="transferred")
  - Pipeline processes issues correctly

## Before/After

**Before**: All webhook events skipped with "repository not configured"
**After**: Repository configuration matching works, pipeline processes normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)