### PR TITLE
fix: update stale issue/PR state in similar threads

### DIFF
--- a/cmd/simili/commands/index.go
+++ b/cmd/simili/commands/index.go
@@ -262,6 +262,8 @@ func processIssue(ctx context.Context, workerID int, issue *github.Issue, gh *si
 				"text":         chunk,
 				"url":          issue.GetHTMLURL(),
 				"type":         itemType,
+				"state":        issue.GetState(),
+				"title":        issue.GetTitle(),
 			},
 		}
 	}

--- a/internal/integrations/gemini/prompts.go
+++ b/internal/integrations/gemini/prompts.go
@@ -97,9 +97,9 @@ Reasoning: [your analysis]`,
 func buildResponsePrompt(similar []SimilarIssueInput) string {
 	var issueList strings.Builder
 	for i, s := range similar {
-		status := "open"
-		if s.State == "closed" {
-			status = "closed"
+		status := s.State
+		if status == "" || status == "unknown" {
+			status = "unknown"
 		}
 		issueList.WriteString(fmt.Sprintf("%d. #%d: %s (%.0f%% similar, %s)\n   %s\n",
 			i+1, s.Number, s.Title, s.Similarity*100, status, s.URL))

--- a/internal/integrations/qdrant/types.go
+++ b/internal/integrations/qdrant/types.go
@@ -40,6 +40,9 @@ type VectorStore interface {
 	// Delete removes a point by ID.
 	Delete(ctx context.Context, collectionName string, id string) error
 
+	// SetPayload updates payload fields on existing points without re-uploading vectors.
+	SetPayload(ctx context.Context, collectionName string, id string, payload map[string]interface{}) error
+
 	// Close closes the connection to the database.
 	Close() error
 }

--- a/internal/steps/response_builder.go
+++ b/internal/steps/response_builder.go
@@ -234,9 +234,14 @@ func (s *ResponseBuilder) buildSimilarSection(ctx *pipeline.Context) string {
 	parts = append(parts, "| :--- | :--- | :--- |")
 
 	for _, similar := range ctx.SimilarIssues {
-		status := "Open"
-		if similar.State == "closed" {
+		var status string
+		switch similar.State {
+		case "closed":
 			status = "Closed"
+		case "open":
+			status = "Open"
+		default:
+			status = "—"
 		}
 
 		// Truncate title if too long (UTF-8 safe)

--- a/internal/steps/similarity.go
+++ b/internal/steps/similarity.go
@@ -127,7 +127,7 @@ func (s *SimilaritySearch) Run(ctx *pipeline.Context) error {
 		url, _ := res.Payload["url"].(string)
 		state, _ := res.Payload["state"].(string)
 		if state == "" {
-			state = "open" // Default
+			state = "unknown"
 		}
 
 		issue := pipeline.SimilarIssue{


### PR DESCRIPTION
## Summary

Fixes #59 — Closed issues and PRs were incorrectly shown as "Open" in Simili bot comments.

## Root Cause

When issues/PRs are indexed into Qdrant, their `state` is stored at index time. When the issue is later closed or reopened, the stored state is **never updated** because:

1. **Bulk indexer** (`simili index`) did not store `state` or `title` in payload at all
2. **No state-update path** existed — the only option was full re-embedding (expensive and unnecessary)
3. **Similarity search** defaulted missing state to `"open"`, masking the problem

## Changes

| File | Change |
|---|---|
| `qdrant/types.go` | Add `SetPayload` to `VectorStore` interface |
| `qdrant/client.go` | Implement `SetPayload` — updates payload fields without re-uploading vectors |
| `steps/indexer.go` | Detect `closed`/`reopened` events → patch state via `SetPayload` (no re-embed) |
| `commands/index.go` | Include `state` and `title` in bulk indexer payloads |
| `steps/similarity.go` | Default missing state to `"unknown"` instead of `"open"` |
| `steps/response_builder.go` | Render unknown state as `—` in status column |
| `gemini/prompts.go` | Pass actual state to LLM prompt instead of assuming open |

## How It Works

```
Close event → indexer detects EventAction="closed"
           → generates deterministic UUID (same as original index)
           → calls SetPayload(id, {state: "closed"})
           → Qdrant updates payload in-place, vector untouched
           → next similarity search reads correct state
```

## Testing

- `go build ./...` ✅
- `go vet ./...` ✅  
- `go test ./...` ✅ (all 8 packages pass)

## Backward Compatibility

- Existing indexed points without `state` field will show `—` instead of incorrectly showing `Open`
- Running `simili index --repo ...` will now store `state` for all new/updated points
- No breaking changes to config or CLI flags

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Optimized indexing for state-only changes (e.g., when issues are opened or closed) to skip unnecessary re-embedding and improve performance.
  * Issue state and title fields now tracked alongside indexed content.

* **Improvements**
  * Enhanced state handling for similar issues with more explicit and consistent display logic to properly handle all state variations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->