### PR TITLE
fix: prevent bot loop on pull_request.edited events

### DIFF
--- a/cmd/simili/commands/process.go
+++ b/cmd/simili/commands/process.go
@@ -1,7 +1,7 @@
 // Author: Kaviru Hapuarachchi
 // GitHub: https://github.com/kavirubc
 // Created: 2026-02-02
-// Last Modified: 2026-02-02
+// Last Modified: 2026-02-17
 
 package commands
 
@@ -323,6 +323,18 @@ func enrichIssueFromGitHubEvent(issue *pipeline.Issue, raw map[string]interface{
 
 	if issue.EventType == "" {
 		issue.EventType = os.Getenv("GITHUB_EVENT_NAME")
+	}
+
+	// Fall back to sender.login so the gatekeeper can filter bot-triggered
+	// pull_request.edited (and similar) events, not just issue_comment events.
+	// CommentAuthor is already set for issue_comment events; for all other event
+	// types it remains empty and the gatekeeper's bot-author check is skipped.
+	if issue.CommentAuthor == "" {
+		if sender, ok := raw["sender"].(map[string]interface{}); ok {
+			if login, ok := sender["login"].(string); ok {
+				issue.CommentAuthor = login
+			}
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

Closes a residual loop not covered by #62.

**Root cause:** The gatekeeper's bot-author check relied on `CommentAuthor`, which was only populated for `issue_comment` events (from `comment.user.login`). For `pull_request.edited` and other PR events `CommentAuthor` stayed empty, so this guard always short-circuited:

```go
if ctx.Issue.CommentAuthor != "" {  // never true for PR events
    if isBotAuthor(author, ...) { skip }
}
```

**What this caused:** When `coderabbitai[bot]` (or any bot) edits a PR (e.g. submitting a review), GitHub fires a `pull_request.edited` event. The gatekeeper could not detect the actor was a bot, so the triage pipeline ran again — posting a duplicate triage report and applying additional labels.

**Fix:** In `enrichIssueFromGitHubEvent`, fall back to `sender.login` when `CommentAuthor` is not already set. The `sender` field is present in **all** GitHub webhook payloads and correctly identifies who triggered the event — giving the gatekeeper full coverage across all event types, not just comments.

## How it works

| Event type | Before | After |
|---|---|---|
| `issue_comment` (bot comment) | Caught ✅ | Caught ✅ |
| `pull_request.edited` by bot | **Not caught ❌** | Caught ✅ |
| `pull_request.opened` by human | Runs normally ✅ | Runs normally ✅ |
| `pull_request.synchronize` by human | Runs normally ✅ | Runs normally ✅ |

## Test plan

- [ ] Build passes: `go build ./...`
- [ ] All tests pass: `go test ./...`
- [ ] After merge: verify triage runs exactly once when a PR is opened and CodeRabbit posts a review
- [ ] Verify human-opened PRs still trigger triage normally

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed event attribution for bot-triggered operations in pull requests, ensuring access control validation is consistently applied across all event types including edited events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->