### PR TITLE
fix: prevent bot loop & enable E2E for forks

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -227,8 +227,11 @@ jobs:
           jobs:
             triage:
               runs-on: ubuntu-latest
-              # Prevent the bot's own comment from re-triggering the workflow
-              if: github.actor != 'gh-simili-bot' && github.actor != 'github-actions[bot]'
+              # Skip only when the bot itself posts a comment (prevents feedback loop).
+              # Always run for issues: opened/edited events.
+              if: >
+                github.event_name != 'issue_comment' ||
+                (github.actor != 'gh-simili-bot' && github.actor != 'github-actions[bot]')
               steps:
                 - name: Checkout
                   uses: actions/checkout@v4

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -16,9 +16,11 @@ permissions:
 jobs:
   triage:
     runs-on: ubuntu-latest
-    # Don't run when the bot itself creates a comment — prevents the feedback loop
-    # where the bot's own comment re-triggers the workflow.
-    if: github.actor != 'gh-simili-bot' && github.actor != 'github-actions[bot]'
+    # Skip only when the bot itself posts a comment (prevents feedback loop).
+    # Always run for issues: opened/edited/reopened events.
+    if: >
+      github.event_name != 'issue_comment' ||
+      (github.actor != 'gh-simili-bot' && github.actor != 'github-actions[bot]')
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
## Problem

1. **Bot Loop (#73)**: When the bot posts a triage comment, the `issue_comment: created` event re-triggers the triage workflow, causing a double-post loop.
2. **Fork Failures (#75)**: Forked PRs fail the E2E test because they run with restricted permissions (read-only token, no secrets), so `BOT_PAT` and API keys are missing.

## Fixes

1. **Loop Guard**: Added `if:` guard to skip triage execution when actor is `gh-simili-bot` or `github-actions[bot]`. Applied to both main `triage.yml` and generated test workflow.
2. **Fork Support**: Switched E2E trigger to `pull_request_target`. This runs in the context of the base branch (main) with full secrets access, but explicitly checks out the PR code.

Fixes #73. Enables CI for external contributors.