### PR TITLE
fix: run E2E only when review is approved (secure for forks)

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -406,7 +406,7 @@ jobs:
       - name: Comment on PR
         if: always() && (github.event_name == 'pull_request_review' || github.event_name == 'workflow_dispatch')
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.BOT_PAT }}
           PR_NUM: ${{ github.event.pull_request.number || inputs.pr_number }}
           CO_SHA: ${{ github.event.pull_request.head.sha || inputs.sha }}
         run: |


### PR DESCRIPTION
## Problem

Forked PRs trigger `pull_request`, which has no access to secrets. This causes E2E failure. Using `pull_request_target` grants secret access but is risky if run automatically.

## Solution

Switch trigger to **`pull_request_review`** (submitted).
- The workflow runs **only** when a review is submitted AND the state is **'approved'**.
- This ensures a maintainer has reviewed the code before it runs with secret access.
- Explicitly checks out the PR code (`ref: head.sha`) to test the changes.

## How to Test

1. Approve this PR (simulating a maintainer approval).
2. The workflow should trigger automatically.
3. Or use the **manual trigger** (`workflow_dispatch`) for debugging.

Fixes #77

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Modified E2E test workflow to trigger on approved pull request reviews instead of all pull requests
  * Added manual workflow dispatch capability with custom input parameters
  * Enhanced pull request and commit tracking in CI/CD pipelines

<!-- end of auto-generated comment: release notes by coderabbit.ai -->