### PR TITLE
fix: use 'e2e' label trigger for secure secrets access

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -16,8 +16,8 @@
 name: Simili E2E Test
 
 on:
-  pull_request_review:
-    types: [submitted]
+  pull_request_target:
+    types: [labeled]
   workflow_dispatch:
     inputs:
       sha:
@@ -44,8 +44,8 @@ jobs:
     name: E2E Integration Test
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    # Only run if the review was approved (or manual trigger)
-    if: github.event.review.state == 'approved' || github.event_name == 'workflow_dispatch'
+    # Only run if the 'e2e' label was added (or manual trigger)
+    if: github.event.label.name == 'e2e' || github.event_name == 'workflow_dispatch'
 
     steps:
       # ----- 0. Validate secrets -----


### PR DESCRIPTION
## Problem
The previous fix used `pull_request_review` to trigger E2E tests. However, workflows triggered by reviews on forked PRs **do not have access to secrets**, regardless of approval status. This caused the E2E workflow to fail immediately.

## Solution
Switch trigger to **`pull_request_target`** (types: `labeled`).
- **Secret Access**: Valid (runs in base repo context).
- **Security Gate**: Runs ONLY when the `e2e` label is added.
- **Verification**: Maintainers must review code, approve, and then add the `e2e` label to run the test.

Checks out PR code securely via explicit `ref` logic.