### PR TITLE
fix: enable E2E report comment for labeled trigger

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -404,7 +404,7 @@ jobs:
 
       # ----- 14. PR comment with link to test repo -----
       - name: Comment on PR
-        if: always() && (github.event_name == 'pull_request_review' || github.event_name == 'workflow_dispatch')
+        if: always() && (github.event_name == 'pull_request_target' || github.event_name == 'workflow_dispatch')
         env:
           GH_TOKEN: ${{ secrets.BOT_PAT }}
           PR_NUM: ${{ github.event.pull_request.number || inputs.pr_number }}


### PR DESCRIPTION
## Fix
The E2E workflow ran successfully on PRs, but the **Report Comment** was skipped.
Why? The step condition checked for `pull_request_review` (old trigger), but we are now using `pull_request_target`.

Updated the condition to match `pull_request_target` so the bot posts the test results.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the GitHub Actions workflow trigger for automated PR comments to respond to pull request target events instead of pull request review events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->