### PR TITLE
feat: add auto-close command for duplicate issues

### DIFF
--- a/.github/workflows/auto-close.yml
+++ b/.github/workflows/auto-close.yml
@@ -1,0 +1,61 @@
+# =============================================================================
+# Auto-Close Duplicate Issues
+# =============================================================================
+# Runs daily at 10:00 UTC to close issues whose grace period has expired.
+# Also supports manual trigger via workflow_dispatch.
+#
+# Required secrets:
+#   GH_PAT         – Token with issues:write permission
+# =============================================================================
+
+name: Auto-Close Duplicates
+
+on:
+  schedule:
+    # Daily at 10:00 UTC
+    - cron: '0 10 * * *'
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Run in dry-run mode (no side effects)'
+        required: false
+        default: 'false'
+        type: choice
+        options:
+          - 'false'
+          - 'true'
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  auto-close:
+    name: Auto-Close Expired Duplicates
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.23'
+
+      - name: Build CLI
+        run: go build -o simili-cli ./cmd/simili/main.go
+
+      - name: Run auto-close
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_PAT }}
+        run: |
+          DRY_RUN_FLAG=""
+          if [ "${{ inputs.dry_run }}" = "true" ]; then
+            DRY_RUN_FLAG="--dry-run"
+          fi
+
+          ./simili-cli auto-close \
+            --repo "${{ github.repository }}" \
+            --config .github/simili.yaml \
+            --verbose \
+            $DRY_RUN_FLAG

--- a/cmd/simili/commands/auto_close.go
+++ b/cmd/simili/commands/auto_close.go
@@ -1,0 +1,176 @@
+// Author: Sachindu Nethmin
+// GitHub: https://github.com/Sachindu-Nethmin
+// Created: 2026-02-22
+// Last Modified: 2026-02-22
+
+package commands
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/similigh/simili-bot/internal/core/config"
+	"github.com/similigh/simili-bot/internal/integrations/github"
+	"github.com/similigh/simili-bot/internal/steps"
+)
+
+var (
+	autoCloseRepo    string
+	autoCloseDry     bool
+	graceMinutesFlag int
+)
+
+// autoCloseCmd represents the auto-close command
+var autoCloseCmd = &cobra.Command{
+	Use:   "auto-close",
+	Short: "Auto-close confirmed duplicate issues after their grace period",
+	Long: `Scans issues labeled 'potential-duplicate' and closes those whose
+grace period has expired and have no human activity since labeling.
+
+The grace period is configured via auto_close.grace_period_hours in the
+config file (default: 72 hours).
+
+Usage:
+  simili auto-close --repo owner/name [--config path] [--dry-run] [--verbose]
+
+Environment variables:
+  GITHUB_TOKEN   Required. Token with issues:write permission.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		runAutoClose()
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(autoCloseCmd)
+
+	autoCloseCmd.Flags().StringVar(&autoCloseRepo, "repo", "", "Repository in owner/name format (or set GITHUB_REPOSITORY)")
+	autoCloseCmd.Flags().BoolVar(&autoCloseDry, "dry-run", false, "Log actions without executing them")
+	autoCloseCmd.Flags().IntVar(&graceMinutesFlag, "grace-minutes", 0, "Override grace period in minutes (for testing; 0 = use config)")
+}
+
+func runAutoClose() {
+	// 1. Resolve org/repo
+	org, repo := resolveAutoCloseRepo(autoCloseRepo)
+	if org == "" || repo == "" {
+		fmt.Println("Error: --repo owner/name is required (or set GITHUB_REPOSITORY)")
+		os.Exit(1)
+	}
+
+	// 2. Load config
+	cfg := loadAutoCloseConfig()
+
+	// 3. Initialize GitHub client
+	token := os.Getenv("GITHUB_TOKEN")
+	if token == "" {
+		fmt.Println("Error: GITHUB_TOKEN environment variable is required")
+		os.Exit(1)
+	}
+
+	ctx := context.Background()
+	ghClient := github.NewClient(ctx, token)
+
+	// 4. Apply CLI override for grace period
+	if graceMinutesFlag > 0 {
+		cfg.AutoClose.GracePeriodMinutesOverride = graceMinutesFlag
+		if verbose {
+			fmt.Printf("Grace period overridden to %d minutes via --grace-minutes\n", graceMinutesFlag)
+		}
+	}
+
+	// 5. Run auto-closer
+	closer := steps.NewAutoCloser(ghClient, cfg, autoCloseDry, verbose)
+
+	fmt.Printf("[Simili-Bot] Running auto-close for %s/%s...\n", org, repo)
+	result, err := closer.Run(ctx, org, repo)
+	if err != nil {
+		fmt.Printf("❌ Auto-close failed: %v\n", err)
+		os.Exit(1)
+	}
+
+	// 5. Print summary
+	fmt.Printf("\n=== Auto-Close Summary ===\n")
+	fmt.Printf("Processed: %d\n", result.Processed)
+	fmt.Printf("Closed:    %d\n", result.Closed)
+	fmt.Printf("Skipped (grace period):    %d\n", result.SkippedGrace)
+	fmt.Printf("Skipped (human activity):  %d\n", result.SkippedHuman)
+	if len(result.Errors) > 0 {
+		fmt.Printf("Errors:    %d\n", len(result.Errors))
+	}
+
+	resultBytes, err := json.MarshalIndent(result, "", "  ")
+	if err == nil {
+		fmt.Println("\n=== Detailed Result ===")
+		fmt.Println(string(resultBytes))
+	}
+
+	if len(result.Errors) > 0 {
+		os.Exit(1)
+	}
+}
+
+func resolveAutoCloseRepo(flagRepo string) (string, string) {
+	if flagRepo != "" && strings.Contains(flagRepo, "/") {
+		parts := strings.SplitN(flagRepo, "/", 2)
+		if len(parts) == 2 {
+			return strings.TrimSpace(parts[0]), strings.TrimSpace(parts[1])
+		}
+	}
+
+	if ghRepo := strings.TrimSpace(os.Getenv("GITHUB_REPOSITORY")); ghRepo != "" {
+		parts := strings.SplitN(ghRepo, "/", 2)
+		if len(parts) == 2 {
+			return strings.TrimSpace(parts[0]), strings.TrimSpace(parts[1])
+		}
+	}
+
+	return "", ""
+}
+
+func loadAutoCloseConfig() *config.Config {
+	actualCfgPath := cfgFile
+	if actualCfgPath == "" {
+		actualCfgPath = config.FindConfigPath("")
+	}
+
+	if actualCfgPath == "" {
+		if verbose {
+			fmt.Println("No configuration file found. Using defaults.")
+		}
+		cfg := &config.Config{}
+		return cfg
+	}
+
+	// Build fetcher for config inheritance
+	var configToken string
+	if token := os.Getenv("GITHUB_TOKEN"); token != "" {
+		configToken = token
+	}
+
+	fetcher := func(ref string) ([]byte, error) {
+		org, repo, branch, path, err := config.ParseExtendsRef(ref)
+		if err != nil {
+			return nil, err
+		}
+		if configToken == "" {
+			return nil, fmt.Errorf("GITHUB_TOKEN required to fetch remote config %s", ref)
+		}
+		ghClient := github.NewClient(context.Background(), configToken)
+		return ghClient.GetFileContent(context.Background(), org, repo, path, branch)
+	}
+
+	cfg, err := config.LoadWithInheritance(actualCfgPath, fetcher)
+	if err != nil {
+		fmt.Printf("Warning: Failed to load config: %v. Using defaults.\n", err)
+		return &config.Config{}
+	}
+
+	if verbose {
+		fmt.Printf("Loaded config from %s\n", actualCfgPath)
+	}
+	return cfg
+}

--- a/internal/integrations/github/client_test.go
+++ b/internal/integrations/github/client_test.go
@@ -69,3 +69,17 @@ func TestTransferIssueValidation(t *testing.T) {
 		})
 	}
 }
+
+func TestRemoveLabelValidation(t *testing.T) {
+	client := &Client{client: nil}
+
+	err := client.RemoveLabel(context.Background(), "org", "repo", 1, "")
+	if err == nil {
+		t.Error("Expected error for empty label")
+	}
+
+	err = client.RemoveLabel(context.Background(), "org", "repo", 1, "   ")
+	if err == nil {
+		t.Error("Expected error for whitespace-only label")
+	}
+}

--- a/internal/steps/auto_closer.go
+++ b/internal/steps/auto_closer.go
@@ -1,0 +1,310 @@
+// Author: Sachindu Nethmin
+// GitHub: https://github.com/Sachindu-Nethmin
+// Created: 2026-02-22
+// Last Modified: 2026-02-22
+
+// Package steps provides the auto-closer logic for confirmed duplicate issues.
+package steps
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"strings"
+	"time"
+
+	githubapi "github.com/google/go-github/v60/github"
+
+	"github.com/similigh/simili-bot/internal/core/config"
+	"github.com/similigh/simili-bot/internal/integrations/github"
+)
+
+// AutoCloseResult holds the summary of an auto-close run.
+type AutoCloseResult struct {
+	Processed    int               `json:"processed"`
+	Closed       int               `json:"closed"`
+	SkippedGrace int               `json:"skipped_grace_period"`
+	SkippedHuman int               `json:"skipped_human_activity"`
+	Errors       []string          `json:"errors,omitempty"`
+	Details      []AutoCloseDetail `json:"details,omitempty"`
+}
+
+// AutoCloseDetail records the outcome for a single issue.
+type AutoCloseDetail struct {
+	Number int    `json:"number"`
+	Action string `json:"action"` // "closed", "skipped_grace", "skipped_human", "error"
+	Reason string `json:"reason,omitempty"`
+}
+
+// AutoCloser scans issues with the potential-duplicate label and closes
+// those whose grace period has expired and have no human activity.
+type AutoCloser struct {
+	github  *github.Client
+	cfg     *config.Config
+	dryRun  bool
+	verbose bool
+}
+
+// NewAutoCloser creates a new AutoCloser.
+func NewAutoCloser(gh *github.Client, cfg *config.Config, dryRun, verbose bool) *AutoCloser {
+	return &AutoCloser{
+		github:  gh,
+		cfg:     cfg,
+		dryRun:  dryRun || cfg.AutoClose.DryRun,
+		verbose: verbose,
+	}
+}
+
+// Run processes all open issues with the "potential-duplicate" label.
+func (ac *AutoCloser) Run(ctx context.Context, org, repo string) (*AutoCloseResult, error) {
+	if ac.github == nil {
+		return nil, fmt.Errorf("GitHub client is required for auto-close")
+	}
+
+	result := &AutoCloseResult{}
+
+	// Determine grace period: CLI minutes override takes precedence
+	var gracePeriod time.Duration
+	if ac.cfg.AutoClose.GracePeriodMinutesOverride > 0 {
+		gracePeriod = time.Duration(ac.cfg.AutoClose.GracePeriodMinutesOverride) * time.Minute
+	} else {
+		gracePeriodHours := ac.cfg.AutoClose.GracePeriodHours
+		if gracePeriodHours <= 0 {
+			gracePeriodHours = 72 // Safety default: 3 days
+		}
+		gracePeriod = time.Duration(gracePeriodHours) * time.Hour
+	}
+
+	if ac.verbose {
+		log.Printf("[auto-closer] Grace period: %v", gracePeriod)
+	}
+
+	// Fetch open issues labeled "potential-duplicate"
+	issues, err := ac.fetchPotentialDuplicates(ctx, org, repo)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch potential-duplicate issues: %w", err)
+	}
+
+	if ac.verbose {
+		log.Printf("[auto-closer] Found %d open issues with 'potential-duplicate' label", len(issues))
+	}
+
+	for _, issue := range issues {
+		number := issue.GetNumber()
+		result.Processed++
+
+		detail := AutoCloseDetail{Number: number}
+
+		// 1. Check grace period
+		labeledAt, err := ac.findLabeledTime(ctx, org, repo, number, "potential-duplicate")
+		if err != nil {
+			detail.Action = "error"
+			detail.Reason = fmt.Sprintf("failed to check label time: %v", err)
+			result.Errors = append(result.Errors, fmt.Sprintf("#%d: %s", number, detail.Reason))
+			result.Details = append(result.Details, detail)
+			continue
+		}
+
+		if labeledAt.IsZero() {
+			detail.Action = "error"
+			detail.Reason = "could not find when 'potential-duplicate' label was applied"
+			result.Errors = append(result.Errors, fmt.Sprintf("#%d: %s", number, detail.Reason))
+			result.Details = append(result.Details, detail)
+			continue
+		}
+
+		elapsed := time.Since(labeledAt)
+		if elapsed < gracePeriod {
+			remaining := gracePeriod - elapsed
+			detail.Action = "skipped_grace"
+			detail.Reason = fmt.Sprintf("grace period: %s remaining", remaining.Round(time.Hour))
+			result.SkippedGrace++
+			result.Details = append(result.Details, detail)
+			if ac.verbose {
+				log.Printf("[auto-closer] #%d: %s", number, detail.Reason)
+			}
+			continue
+		}
+
+		// 2. Check for human activity since the label was applied
+		hasHuman, err := ac.hasHumanActivity(ctx, org, repo, number, labeledAt)
+		if err != nil {
+			detail.Action = "error"
+			detail.Reason = fmt.Sprintf("failed to check human activity: %v", err)
+			result.Errors = append(result.Errors, fmt.Sprintf("#%d: %s", number, detail.Reason))
+			result.Details = append(result.Details, detail)
+			continue
+		}
+
+		if hasHuman {
+			detail.Action = "skipped_human"
+			detail.Reason = "human activity detected after label was applied"
+			result.SkippedHuman++
+			result.Details = append(result.Details, detail)
+			if ac.verbose {
+				log.Printf("[auto-closer] #%d: %s", number, detail.Reason)
+			}
+			continue
+		}
+
+		// 3. Close the issue
+		if ac.dryRun {
+			detail.Action = "closed"
+			detail.Reason = "DRY RUN: would close, swap labels, and comment"
+			result.Closed++
+			result.Details = append(result.Details, detail)
+			log.Printf("[auto-closer] DRY RUN: would close #%d", number)
+			continue
+		}
+
+		if err := ac.closeIssue(ctx, org, repo, number); err != nil {
+			detail.Action = "error"
+			detail.Reason = fmt.Sprintf("failed to close: %v", err)
+			result.Errors = append(result.Errors, fmt.Sprintf("#%d: %s", number, detail.Reason))
+			result.Details = append(result.Details, detail)
+			continue
+		}
+
+		detail.Action = "closed"
+		detail.Reason = "grace period expired, no human activity"
+		result.Closed++
+		result.Details = append(result.Details, detail)
+		log.Printf("[auto-closer] Closed #%d: %s", number, detail.Reason)
+	}
+
+	return result, nil
+}
+
+// fetchPotentialDuplicates retrieves all open issues with the "potential-duplicate" label.
+func (ac *AutoCloser) fetchPotentialDuplicates(ctx context.Context, org, repo string) ([]*githubapi.Issue, error) {
+	var all []*githubapi.Issue
+	opts := &githubapi.IssueListByRepoOptions{
+		State:  "open",
+		Labels: []string{"potential-duplicate"},
+		ListOptions: githubapi.ListOptions{
+			PerPage: 100,
+		},
+	}
+
+	for {
+		issues, resp, err := ac.github.ListIssues(ctx, org, repo, opts)
+		if err != nil {
+			return nil, err
+		}
+		// Filter out pull requests (GitHub API returns PRs as issues)
+		for _, issue := range issues {
+			if issue.PullRequestLinks == nil {
+				all = append(all, issue)
+			}
+		}
+		if resp == nil || resp.NextPage == 0 {
+			break
+		}
+		opts.Page = resp.NextPage
+	}
+
+	return all, nil
+}
+
+// findLabeledTime finds when the "potential-duplicate" label was most recently applied.
+func (ac *AutoCloser) findLabeledTime(ctx context.Context, org, repo string, number int, label string) (time.Time, error) {
+	events, err := ac.github.ListIssueEvents(ctx, org, repo, number)
+	if err != nil {
+		return time.Time{}, err
+	}
+
+	var latest time.Time
+	for _, event := range events {
+		if event.Event != nil && *event.Event == "labeled" {
+			if event.Label != nil && event.Label.Name != nil && *event.Label.Name == label {
+				if event.CreatedAt != nil && event.CreatedAt.Time.After(latest) {
+					latest = event.CreatedAt.Time
+				}
+			}
+		}
+	}
+
+	return latest, nil
+}
+
+// hasHumanActivity checks if any non-bot user commented on the issue after the given time.
+func (ac *AutoCloser) hasHumanActivity(ctx context.Context, org, repo string, number int, since time.Time) (bool, error) {
+	opts := &githubapi.IssueListCommentsOptions{
+		Since: &since,
+		ListOptions: githubapi.ListOptions{
+			PerPage: 100,
+		},
+	}
+
+	comments, _, err := ac.github.ListComments(ctx, org, repo, number, opts)
+	if err != nil {
+		return false, err
+	}
+
+	for _, comment := range comments {
+		if comment.User == nil {
+			continue
+		}
+		author := comment.User.GetLogin()
+		if !isBotUser(author, ac.cfg.BotUsers) {
+			if ac.verbose {
+				log.Printf("[auto-closer] #%d: human comment by %q at %v",
+					number, author, comment.CreatedAt.Time)
+			}
+			return true, nil
+		}
+	}
+
+	return false, nil
+}
+
+// isBotUser checks if the given username matches a known bot pattern.
+func isBotUser(author string, configBotUsers []string) bool {
+	if strings.HasSuffix(author, "[bot]") ||
+		strings.HasPrefix(author, "gh-simili") ||
+		strings.EqualFold(author, "simili-bot") {
+		return true
+	}
+	for _, u := range configBotUsers {
+		if strings.EqualFold(author, u) {
+			return true
+		}
+	}
+	return false
+}
+
+// closeIssue performs the close: swap labels, post comment, close issue.
+func (ac *AutoCloser) closeIssue(ctx context.Context, org, repo string, number int) error {
+	// Post closing comment
+	comment := fmt.Sprintf(
+		"<!-- simili-bot-auto-close -->\n"+
+			"### Auto-Closed as Duplicate\n\n"+
+			"This issue was automatically closed because it was marked as a **potential duplicate** "+
+			"and no objections were raised during the %d-hour grace period.\n\n"+
+			"If this was closed in error, please reopen this issue and leave a comment explaining "+
+			"why it is not a duplicate.\n\n"+
+			"---\n"+
+			"<sub>Generated by [Simili Bot](https://github.com/similigh/simili-bot)</sub>",
+		ac.cfg.AutoClose.GracePeriodHours,
+	)
+
+	if err := ac.github.CreateComment(ctx, org, repo, number, comment); err != nil {
+		return fmt.Errorf("failed to post closing comment: %w", err)
+	}
+
+	// Swap labels: remove "potential-duplicate", add "duplicate"
+	if err := ac.github.RemoveLabel(ctx, org, repo, number, "potential-duplicate"); err != nil {
+		log.Printf("[auto-closer] Warning: failed to remove 'potential-duplicate' label from #%d: %v", number, err)
+	}
+
+	if err := ac.github.AddLabels(ctx, org, repo, number, []string{"duplicate"}); err != nil {
+		log.Printf("[auto-closer] Warning: failed to add 'duplicate' label to #%d: %v", number, err)
+	}
+
+	// Close the issue
+	if err := ac.github.CloseIssue(ctx, org, repo, number); err != nil {
+		return fmt.Errorf("failed to close issue: %w", err)
+	}
+
+	return nil
+}

--- a/internal/steps/auto_closer_test.go
+++ b/internal/steps/auto_closer_test.go
@@ -1,0 +1,95 @@
+// Author: Sachindu Nethmin
+// GitHub: https://github.com/Sachindu-Nethmin
+// Created: 2026-02-22
+// Last Modified: 2026-02-22
+
+package steps
+
+import (
+	"testing"
+	"time"
+)
+
+func TestIsBotUser(t *testing.T) {
+	tests := []struct {
+		name     string
+		author   string
+		botUsers []string
+		want     bool
+	}{
+		{"bot suffix", "dependabot[bot]", nil, true},
+		{"simili prefix", "gh-simili-bot", nil, true},
+		{"simili-bot name", "simili-bot", nil, true},
+		{"normal user", "john-doe", nil, false},
+		{"configured bot", "my-ci-bot", []string{"my-ci-bot"}, true},
+		{"configured bot case insensitive", "MY-CI-BOT", []string{"my-ci-bot"}, true},
+		{"not in configured list", "random-user", []string{"my-ci-bot"}, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isBotUser(tt.author, tt.botUsers)
+			if got != tt.want {
+				t.Errorf("isBotUser(%q, %v) = %v, want %v", tt.author, tt.botUsers, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGracePeriodCalculation(t *testing.T) {
+	gracePeriod := 72 * time.Hour
+
+	tests := []struct {
+		name      string
+		labeledAt time.Time
+		expired   bool
+	}{
+		{
+			name:      "labeled 1 hour ago - not expired",
+			labeledAt: time.Now().Add(-1 * time.Hour),
+			expired:   false,
+		},
+		{
+			name:      "labeled 71 hours ago - not expired",
+			labeledAt: time.Now().Add(-71 * time.Hour),
+			expired:   false,
+		},
+		{
+			name:      "labeled 73 hours ago - expired",
+			labeledAt: time.Now().Add(-73 * time.Hour),
+			expired:   true,
+		},
+		{
+			name:      "labeled 7 days ago - expired",
+			labeledAt: time.Now().Add(-7 * 24 * time.Hour),
+			expired:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			elapsed := time.Since(tt.labeledAt)
+			got := elapsed >= gracePeriod
+			if got != tt.expired {
+				t.Errorf("grace period check: elapsed=%v, got expired=%v, want %v",
+					elapsed, got, tt.expired)
+			}
+		})
+	}
+}
+
+func TestAutoCloseResultCounts(t *testing.T) {
+	result := &AutoCloseResult{
+		Processed:    5,
+		Closed:       2,
+		SkippedGrace: 2,
+		SkippedHuman: 1,
+	}
+
+	total := result.Closed + result.SkippedGrace + result.SkippedHuman
+	if total != result.Processed {
+		// Errors could make it unbalanced, but without errors they should match
+		t.Errorf("counts don't add up: closed(%d) + grace(%d) + human(%d) = %d, want %d",
+			result.Closed, result.SkippedGrace, result.SkippedHuman, total, result.Processed)
+	}
+}

--- a/internal/steps/duplicate_detector.go
+++ b/internal/steps/duplicate_detector.go
@@ -105,6 +105,8 @@ func (s *DuplicateDetector) Run(ctx *pipeline.Context) error {
 		ctx.Result.IsDuplicate = true
 		ctx.Result.DuplicateOf = result.DuplicateOf
 		ctx.Result.DuplicateConfidence = result.Confidence
+		// Add "potential-duplicate" label for the auto-close workflow
+		ctx.Result.SuggestedLabels = append(ctx.Result.SuggestedLabels, "potential-duplicate")
 		log.Printf("[duplicate_detector] Duplicate detected: #%d (%.2f confidence)",
 			result.DuplicateOf, result.Confidence)
 	} else {

--- a/internal/steps/response_builder.go
+++ b/internal/steps/response_builder.go
@@ -292,6 +292,15 @@ func (s *ResponseBuilder) buildDuplicateSection(ctx *pipeline.Context) string {
 		parts = append(parts, fmt.Sprintf("> _Reason: %s_", duplicateResult.Reasoning))
 	}
 
+	// Auto-close grace period warning
+	gracePeriod := ctx.Config.AutoClose.GracePeriodHours
+	if gracePeriod <= 0 {
+		gracePeriod = 72
+	}
+	parts = append(parts, ">")
+	parts = append(parts, fmt.Sprintf("> ⏳ **This %s will be automatically closed in %d hours** if no objections are raised. "+
+		"If you believe this is **not** a duplicate, please leave a comment explaining why.", subject, gracePeriod))
+
 	parts = append(parts, "")
 	return strings.Join(parts, "\n")
 }


### PR DESCRIPTION
## Summary

Adds the simili auto-close CLI command and a scheduled GitHub Actions workflow that automatically closes confirmed duplicate issues after their grace period expires.

### Changes
- **New CLI command**: simili auto-close --repo owner/name [--dry-run] [--verbose]
- **GitHub client**: Added CloseIssue and RemoveLabel methods
- **Config**: Added uto_close.grace_period_hours (default 72h)
- **Duplicate detector**: Now adds potential-duplicate label when duplicate detected
- **Response builder**: Shows auto-close warning in triage comment
- **Workflow**: uto-close.yml runs daily at 10 AM UTC + manual dispatch
- **Tests**: Unit tests for bot detection, grace period, and GitHub client methods

### Related Issues
- Closes #56
- Depends on #54 (Two-phase duplicate detection)
- Depends on #55 (Human activity detection)

Signed-off-by: Sachindu Nethmin <sachindunethmin@gmail.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Automated workflow to close potential duplicate issues after a configurable grace period (default 72 hours).
  * Grace period respects human activity—issues with recent comments are skipped.
  * Dry-run mode available for testing auto-close operations.
  * Manual workflow trigger option with configurable settings.

* **Tests**
  * Added test coverage for grace period calculation and human activity detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->