### PR TITLE
fix(workflow): use bash array to avoid word-splitting bug in optional flags

### DIFF
--- a/.github/workflows/auto-close.yml
+++ b/.github/workflows/auto-close.yml
@@ -54,19 +54,22 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
         run: |
-          DRY_RUN_FLAG=""
+          # Build the command as an array to avoid word-splitting bugs
+          # with optional flags that may be empty.
+          CMD=(
+            ./simili-cli auto-close
+            --repo "${{ github.repository }}"
+            --config .github/simili.yaml
+            --verbose
+          )
+
           if [ "${{ inputs.dry_run }}" = "true" ]; then
-            DRY_RUN_FLAG="--dry-run"
+            CMD+=(--dry-run)
           fi
 
-          GRACE_FLAG=""
-          if [ -n "${{ inputs.grace_period_minutes }}" ]; then
-            GRACE_FLAG="--grace-period-minutes ${{ inputs.grace_period_minutes }}"
+          GRACE="${{ inputs.grace_period_minutes }}"
+          if [ -n "$GRACE" ]; then
+            CMD+=(--grace-period-minutes "$GRACE")
           fi
 
-          ./simili-cli auto-close \
-            --repo "${{ github.repository }}" \
-            --config .github/simili.yaml \
-            --verbose \
-            $DRY_RUN_FLAG \
-            $GRACE_FLAG
+          "${CMD[@]}"


### PR DESCRIPTION
## Root Cause

In the original workflow, optional CLI flags were built as plain strings:

```bash
GRACE_FLAG="--grace-period-minutes ${{ inputs.grace_period_minutes }}"
...
./simili-cli auto-close --verbose $DRY_RUN_FLAG $GRACE_FLAG
```

When the GitHub Actions template substitutes `${{ inputs.grace_period_minutes }}` with the literal flag name (e.g. due to unexpected input or whitespace), the unquoted `$GRACE_FLAG` expansion passes `--grace-period-minutes` as both the flag and its value — producing:

```
Error: invalid argument "--grace-period-minutes" for "--grace-period-minutes" flag:
strconv.ParseInt: parsing "--grace-period-minutes": invalid syntax
```

## Fix

Replace string-based flag variables with a **bash array**, which correctly handles empty values and quoted strings:

```bash
CMD=(./simili-cli auto-close --repo "..." --config ... --verbose)

if [ "${{ inputs.dry_run }}" = "true" ]; then
  CMD+=(--dry-run)
fi

GRACE="${{ inputs.grace_period_minutes }}"
if [ -n "$GRACE" ]; then
  CMD+=(--grace-period-minutes "$GRACE")
fi

"${CMD[@]}"
```

The same fix was applied to `similigh/event-integrator-vscode` (PR #37, now merged).

## Test plan

- [ ] Trigger manually via **Actions → Auto-Close Duplicates → Run workflow** with `dry_run: true` and empty `grace_period_minutes`
- [ ] Trigger with an explicit `grace_period_minutes` value (e.g. `1`) and verify the flag is passed correctly
- [ ] Verify scheduled run still passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Auto-close workflow now supports a configurable grace period override parameter (in minutes) for enhanced control.

* **Improvements**
  * Enhanced workflow authentication using the standard GitHub token.
  * Improved command execution handling for better robustness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->